### PR TITLE
Update to Bevy 0.6

### DIFF
--- a/bevy_tileset_core/Cargo.toml
+++ b/bevy_tileset_core/Cargo.toml
@@ -13,8 +13,8 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
 bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.2" }
-bevy = { version = "0.5", default-features = false }
-bevy_tile_atlas = "0.1"
+bevy = { version = "0.6", default-features = false }
+bevy_tile_atlas = "0.2"
 ron = "0.7.0"
 serde = "1.0"
 anyhow = "1.0"

--- a/bevy_tileset_core/src/debug.rs
+++ b/bevy_tileset_core/src/debug.rs
@@ -1,14 +1,17 @@
 //! Used for debugging tilesets
 
-use crate::prelude::{Tileset, Tilesets};
-use bevy::app::AppBuilder;
+use bevy::app::App;
 use bevy::math::Vec3;
-use bevy::prelude::{Assets, Commands, IntoSystem, Local, Plugin, ResMut, SpriteBundle, Transform};
-use bevy::sprite::ColorMaterial;
+use bevy::prelude::{
+	Commands, Component, ConfigurableSystem, Local, Plugin, SpriteBundle, Transform,
+};
+
+use crate::prelude::{Tileset, Tilesets};
 
 /// A component attached to the debug atlas sprite(s)
 ///
 /// This can be used to query for the sprite(s) in other systems
+#[derive(Component)]
 pub struct DebugTilesetSprite;
 
 /// A plugin used to debug tilesets, displaying them as sprites
@@ -25,8 +28,8 @@ pub struct DebugTilesetPlugin {
 }
 
 impl Plugin for DebugTilesetPlugin {
-	fn build(&self, app: &mut AppBuilder) {
-		app.add_system(display_tilesets.system().config(|params| {
+	fn build(&self, app: &mut App) {
+		app.add_system(display_tilesets.config(|params| {
 			params.0 = Some(DebugState {
 				loaded: false,
 				name: self.tileset_name.clone(),
@@ -91,12 +94,7 @@ struct DebugState {
 	position: Vec3,
 }
 
-fn display_tilesets(
-	mut state: Local<DebugState>,
-	tilesets: Tilesets,
-	mut commands: Commands,
-	mut materials: ResMut<Assets<ColorMaterial>>,
-) {
+fn display_tilesets(mut state: Local<DebugState>, tilesets: Tilesets, mut commands: Commands) {
 	if state.loaded {
 		return;
 	}
@@ -108,7 +106,7 @@ fn display_tilesets(
 	let mut spawner = |tileset: &Tileset| {
 		commands
 			.spawn_bundle(SpriteBundle {
-				material: materials.add(tileset.texture().clone().into()),
+				texture: tileset.texture().clone(),
 				transform: Transform::from_translation(state.position + offset),
 				..Default::default()
 			})

--- a/bevy_tileset_core/src/plugin.rs
+++ b/bevy_tileset_core/src/plugin.rs
@@ -6,11 +6,11 @@ use bevy::prelude::*;
 pub struct TilesetPlugin {}
 
 impl Plugin for TilesetPlugin {
-	fn build(&self, app: &mut AppBuilder) {
+	fn build(&self, app: &mut App) {
 		app.add_asset::<Tileset>()
 			.init_asset_loader::<TilesetAssetLoader>()
 			.init_resource::<TilesetMap>()
-			.add_system(tileset_event_sys.system());
+			.add_system(tileset_event_sys);
 	}
 }
 

--- a/bevy_tileset_core/src/tileset/builder.rs
+++ b/bevy_tileset_core/src/tileset/builder.rs
@@ -1,6 +1,6 @@
 use crate::ids::PartialTileId;
 use crate::prelude::*;
-use bevy::prelude::{Handle, Texture};
+use bevy::prelude::{Handle, Image};
 use bevy_tile_atlas::{TextureStore, TileAtlasBuilder, TileAtlasBuilderError};
 use bevy_tileset_tiles::prelude::*;
 use std::collections::HashMap;
@@ -17,7 +17,7 @@ pub struct TilesetBuilder {
 	/// The tile names mapped by their ID
 	tile_names: HashMap<TileGroupId, String>,
 	/// The tile handles mapped by their index in the atlas
-	tile_handles: HashMap<usize, Handle<Texture>>,
+	tile_handles: HashMap<usize, Handle<Image>>,
 	/// The tile IDs mapped by their index in the atlas
 	tile_indices: HashMap<usize, PartialTileId>,
 	/// The current tile group ID being processed
@@ -101,7 +101,7 @@ impl TilesetBuilder {
 	/// # use bevy_tileset_core::prelude::*;
 	/// # use bevy_tileset_core::tiles::*;
 	///
-	/// fn tileset_creator(textures: Res<Assets<Texture>>) {
+	/// fn tileset_creator(textures: Res<Assets<Image>>) {
 	/// 	let mut builder = TilesetBuilder::default();
 	/// 	let tile = TileHandle::new_standard("My Tile", Handle::default());
 	/// 	builder.add_tile(tile, 123, &textures);
@@ -237,7 +237,7 @@ impl TilesetBuilder {
 
 	fn insert_handle<TStore: TextureStore>(
 		&mut self,
-		handle: &Handle<Texture>,
+		handle: &Handle<Image>,
 		textures: &TStore,
 	) -> Result<usize, TilesetError> {
 		if let Some(texture) = textures.get(handle) {
@@ -249,8 +249,8 @@ impl TilesetBuilder {
 
 	pub fn add_texture(
 		&mut self,
-		handle: &Handle<Texture>,
-		texture: &Texture,
+		handle: &Handle<Image>,
+		texture: &Image,
 	) -> Result<usize, TilesetError> {
 		let index = self
 			.atlas_builder

--- a/bevy_tileset_core/src/tileset/impls/auto.rs
+++ b/bevy_tileset_core/src/tileset/impls/auto.rs
@@ -25,6 +25,7 @@ macro_rules! impl_tileset {
 			/// # use bevy::prelude::{Commands, Res};
 			/// # use bevy_ecs_tilemap::MapQuery;
 			/// # use bevy_tileset_core::prelude::*;
+			/// # use bevy_tileset_tiles::prelude::AutoTileRule;
 			///
 			/// fn place_tile(tileset: Res<Tileset>, mut commands: Commands, mut map_query: MapQuery) {
 			/// 	// Matches:
@@ -144,7 +145,6 @@ macro_rules! impl_tileset {
 				};
 
 				let variant = if let Some(idx) = id.variant_index {
-					println!("{}/{}", idx, tile.variants().len());
 					tile.variants().get(idx)?
 				} else {
 					Self::select_variant(tile.variants())?

--- a/bevy_tileset_core/src/tileset/impls/mod.rs
+++ b/bevy_tileset_core/src/tileset/impls/mod.rs
@@ -1,6 +1,6 @@
 //! Implementation details for [`Tileset`] and [`RawTileset`]
 
-use bevy::prelude::{Handle, Texture, TextureAtlas, Vec2};
+use bevy::prelude::{Handle, Image, TextureAtlas, Vec2};
 
 #[cfg(feature = "auto-tile")]
 pub use auto::*;
@@ -93,9 +93,9 @@ macro_rules! impl_tileset {
 			///
 			/// * `index`: The tile's index
 			///
-			/// returns: Option<&Handle<Texture>>
+			/// returns: Option<&Handle<Image>>
 			///
-			pub fn get_tile_handle(&self, index: &usize) -> Option<&Handle<Texture>> {
+			pub fn get_tile_handle(&self, index: &usize) -> Option<&Handle<Image>> {
 				self.tile_handles.get(index)
 			}
 
@@ -244,7 +244,7 @@ impl RawTileset {
 	}
 
 	/// Gets the handle to the `TextureAtlas`'s texture
-	pub fn texture(&self) -> &Handle<Texture> {
+	pub fn texture(&self) -> &Handle<Image> {
 		&self.atlas.texture
 	}
 }
@@ -256,7 +256,7 @@ impl Tileset {
 	}
 
 	/// Gets the handle to the `TextureAtlas`'s texture
-	pub fn texture(&self) -> &Handle<Texture> {
+	pub fn texture(&self) -> &Handle<Image> {
 		&self.texture
 	}
 }

--- a/bevy_tileset_core/src/tileset/load.rs
+++ b/bevy_tileset_core/src/tileset/load.rs
@@ -1,19 +1,19 @@
 use bevy::asset::{Asset, AssetPath, AssetServer, Handle};
-use bevy::prelude::{Res, Texture};
+use bevy::prelude::{Image, Res};
 use bevy_tileset_tiles::prelude::*;
 
 pub trait TextureLoader {
-	fn load_texture<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<Texture>;
+	fn load_texture<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<Image>;
 }
 
 impl TextureLoader for AssetServer {
-	fn load_texture<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<Texture> {
+	fn load_texture<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<Image> {
 		self.load(path)
 	}
 }
 
 impl<'w> TextureLoader for Res<'w, AssetServer> {
-	fn load_texture<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<Texture> {
+	fn load_texture<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<Image> {
 		self.load(path)
 	}
 }
@@ -33,6 +33,7 @@ impl<'w> TextureLoader for Res<'w, AssetServer> {
 ///
 /// ```
 /// # use bevy_tileset_core::prelude::*;
+/// # use bevy_tileset_tiles::prelude::*;
 /// # use bevy::prelude::*;
 ///
 /// fn create_handles(tiles: Vec<TileDef>, asset_server: &AssetServer) -> Vec<TileHandle> {
@@ -53,7 +54,7 @@ pub fn load_tile_handles<TTiles: IntoIterator<Item = TileDef>, TLoader: TextureL
 			name: tile_def.name.clone(),
 			tile: match &tile_def.tile {
 				TileDefType::Standard(path) => TileHandleType::Standard(
-					asset_loader.load_texture::<Texture, &str>(path.as_str()),
+					asset_loader.load_texture::<Image, &str>(path.as_str()),
 				),
 				TileDefType::Animated(anim) => {
 					TileHandleType::Animated(load_animated(anim, asset_loader))
@@ -86,7 +87,7 @@ fn load_animated<TLoader: TextureLoader>(
 		frames: def
 			.frames
 			.iter()
-			.map(|frame| asset_loader.load_texture::<Texture, &str>(frame.as_str()))
+			.map(|frame| asset_loader.load_texture::<Image, &str>(frame.as_str()))
 			.collect(),
 	}
 }
@@ -99,9 +100,9 @@ fn load_variant<TLoader: TextureLoader>(
 	VariantTileHandle {
 		weight: def.weight,
 		tile: match &def.tile {
-			SimpleTileDefType::Standard(path) => SimpleTileHandle::Standard(
-				asset_loader.load_texture::<Texture, &str>(path.as_str()),
-			),
+			SimpleTileDefType::Standard(path) => {
+				SimpleTileHandle::Standard(asset_loader.load_texture::<Image, &str>(path.as_str()))
+			}
 			SimpleTileDefType::Animated(anim) => {
 				SimpleTileHandle::Animated(load_animated(anim, asset_loader))
 			}

--- a/bevy_tileset_core/src/tileset/mod.rs
+++ b/bevy_tileset_core/src/tileset/mod.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use bevy::prelude::{Handle, Texture, TextureAtlas, Vec2};
+use bevy::prelude::{Component, Handle, Image, TextureAtlas, Vec2};
 use bevy::reflect::TypeUuid;
 
 pub(crate) use asset::TilesetAssetLoader;
@@ -46,7 +46,7 @@ macro_rules! define_tileset {
 			/// The tile names mapped by their ID
 			tile_names: HashMap<TileGroupId, String>,
 			/// The tile handles mapped by their index in the atlas
-			tile_handles: HashMap<usize, Handle<Texture>>,
+			tile_handles: HashMap<usize, Handle<Image>>,
 			/// The tile IDs mapped by their index in the atlas
 			tile_indices: HashMap<usize, TileId>,
 			$(
@@ -77,9 +77,10 @@ define_tileset!(
 		/// A handle to the generated texture atlas
 		atlas: Handle<TextureAtlas>,
 		/// A handle to the generated texture atlas's texture
-		texture: Handle<Texture>
+		texture: Handle<Image>
 	}
 );
 
 /// A component used to pair a tile entity with the tileset it comes from
+#[derive(Component)]
 pub struct TilesetParent(pub TilesetId);

--- a/bevy_tileset_core/src/tileset/param.rs
+++ b/bevy_tileset_core/src/tileset/param.rs
@@ -1,14 +1,18 @@
 use crate::prelude::{Tileset, TilesetId};
 use bevy::asset::{Assets, Handle};
 use bevy::ecs::system::SystemParam;
-use bevy::prelude::{Res, ResMut};
+use bevy::prelude::{Query, Res, ResMut};
 use std::collections::HashMap;
 use std::ops::Deref;
 
 #[derive(SystemParam)]
-pub struct Tilesets<'a> {
-	tileset_map: ResMut<'a, TilesetMap>,
-	tilesets: Res<'a, Assets<Tileset>>,
+pub struct Tilesets<'w, 's> {
+	tileset_map: ResMut<'w, TilesetMap>,
+	tilesets: Res<'w, Assets<Tileset>>,
+
+	/// This field only exists so we can add the `'s` lifetime without Rust freaking out
+	#[allow(dead_code)]
+	phantom_query: Query<'w, 's, ()>,
 }
 
 #[derive(Default)]
@@ -19,15 +23,15 @@ pub struct TilesetMap {
 	id_to_name: HashMap<TilesetId, String>,
 }
 
-impl<'a> Deref for Tilesets<'a> {
-	type Target = Res<'a, Assets<Tileset>>;
+impl<'w, 's> Deref for Tilesets<'w, 's> {
+	type Target = Res<'w, Assets<Tileset>>;
 
 	fn deref(&self) -> &Self::Target {
 		&self.tilesets
 	}
 }
 
-impl<'a> Tilesets<'a> {
+impl<'w, 's> Tilesets<'w, 's> {
 	/// Get a tileset by its ID.
 	///
 	/// # Arguments

--- a/bevy_tileset_tiles/Cargo.toml
+++ b/bevy_tileset_tiles/Cargo.toml
@@ -12,8 +12,8 @@ readme = "../README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
-bevy_render = "0.5"
-bevy_asset = "0.5"
+bevy_render = { version = "0.6", default-features = false }
+bevy_asset = { version = "0.6", default-features = false }
 serde = "1.0"
 
 [features]

--- a/bevy_tileset_tiles/src/animated.rs
+++ b/bevy_tileset_tiles/src/animated.rs
@@ -1,5 +1,5 @@
 use bevy_asset::Handle;
-use bevy_render::texture::Texture;
+use bevy_render::texture::Image;
 use serde::{Deserialize, Serialize};
 
 /// A structure defining an animated tile
@@ -23,7 +23,7 @@ pub struct AnimatedTileHandle {
 	/// The frames of the animation
 	///
 	/// Each frame is a registered [`Handle`]
-	pub frames: Vec<Handle<Texture>>,
+	pub frames: Vec<Handle<Image>>,
 }
 
 /// A structure defining an animated tile

--- a/bevy_tileset_tiles/src/auto/rules.rs
+++ b/bevy_tileset_tiles/src/auto/rules.rs
@@ -63,7 +63,7 @@ impl AutoTileRule {
 	/// # Examples
 	///
 	/// ```
-	/// # use tileset_tiles::AutoTileRule;
+	/// # use bevy_tileset_tiles::prelude::AutoTileRule;
 	///
 	/// let a = AutoTileRule { north: Some(true), ..Default::default() };
 	/// let b = AutoTileRule { north: Some(true), east: Some(true), south: Some(false), ..Default::default() };
@@ -123,7 +123,7 @@ impl AutoTileRule {
 
 #[cfg(test)]
 mod tests {
-	use crate::AutoTileRule;
+	use crate::prelude::AutoTileRule;
 
 	#[test]
 	fn should_be_subset() {

--- a/bevy_tileset_tiles/src/tile.rs
+++ b/bevy_tileset_tiles/src/tile.rs
@@ -1,10 +1,10 @@
-use crate::prelude::{AnimatedTileData, AnimatedTileDef, AnimatedTileHandle};
 use bevy_asset::{AssetServer, Handle, LoadState};
-use bevy_render::texture::Texture;
+use bevy_render::texture::Image;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "auto-tile")]
 use crate::auto::*;
+use crate::prelude::{AnimatedTileData, AnimatedTileDef, AnimatedTileHandle};
 #[cfg(feature = "variants")]
 use crate::variants::*;
 
@@ -42,7 +42,7 @@ pub struct TileHandle {
 /// An enum defining the tile's type
 #[derive(Debug, Clone)]
 pub enum TileHandleType {
-	Standard(Handle<Texture>),
+	Standard(Handle<Image>),
 	Animated(AnimatedTileHandle),
 	#[cfg(feature = "variants")]
 	Variant(Vec<VariantTileHandle>),
@@ -159,7 +159,7 @@ impl TileType {
 }
 
 impl TileHandle {
-	pub fn new_standard<TName: Into<String>>(name: TName, handle: Handle<Texture>) -> Self {
+	pub fn new_standard<TName: Into<String>>(name: TName, handle: Handle<Image>) -> Self {
 		Self {
 			name: name.into(),
 			tile: TileHandleType::Standard(handle),
@@ -197,7 +197,7 @@ impl TileHandle {
 		asset_server.get_group_load_state(self.iter_handles().map(|handle| handle.id))
 	}
 
-	pub fn iter_handles(&self) -> Box<dyn Iterator<Item = &Handle<Texture>> + '_> {
+	pub fn iter_handles(&self) -> Box<dyn Iterator<Item = &Handle<Image>> + '_> {
 		match &self.tile {
 			TileHandleType::Standard(handle) => Box::new(std::iter::once(handle)),
 			TileHandleType::Animated(anim) => Box::new(anim.frames.iter()),
@@ -214,10 +214,10 @@ impl TileHandle {
 #[cfg(feature = "variants")]
 fn iter_variant_handles<'a>(
 	variants: impl Iterator<Item = &'a VariantTileHandle>,
-) -> impl Iterator<Item = &'a Handle<Texture>> {
+) -> impl Iterator<Item = &'a Handle<Image>> {
 	variants
 		.map(|variant| {
-			let iter: Box<dyn Iterator<Item = &Handle<Texture>>> = match &variant.tile {
+			let iter: Box<dyn Iterator<Item = &Handle<Image>>> = match &variant.tile {
 				SimpleTileHandle::Standard(handle) => Box::new(std::iter::once(handle)),
 				SimpleTileHandle::Animated(anim) => Box::new(anim.frames.iter()),
 			};
@@ -228,8 +228,9 @@ fn iter_variant_handles<'a>(
 
 #[cfg(test)]
 mod tests {
-	use crate::prelude::*;
 	use bevy_asset::Handle;
+
+	use crate::prelude::*;
 
 	#[test]
 	fn should_iter_standard() {

--- a/bevy_tileset_tiles/src/variants.rs
+++ b/bevy_tileset_tiles/src/variants.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{AnimatedTileData, AnimatedTileDef, AnimatedTileHandle};
 use bevy_asset::Handle;
-use bevy_render::texture::Texture;
+use bevy_render::texture::Image;
 use serde::{Deserialize, Serialize};
 
 /// A structure defining a _variant_ tile
@@ -37,7 +37,7 @@ pub struct VariantTileHandle {
 /// An enum defining "simple" tile types
 #[derive(Debug, Clone)]
 pub enum SimpleTileHandle {
-	Standard(Handle<Texture>),
+	Standard(Handle<Image>),
 	Animated(AnimatedTileHandle),
 }
 

--- a/examples/tileset.rs
+++ b/examples/tileset.rs
@@ -10,14 +10,14 @@ use bevy::prelude::*;
 use bevy_tileset::prelude::*;
 
 fn main() {
-	App::build()
+	App::new()
 		// === Required === //
 		.add_plugins(DefaultPlugins)
 		.add_plugin(TilesetPlugin::default())
 		// /== Required === //
 		.init_resource::<MyTileset>()
-		.add_startup_system(load_tileset.system())
-		.add_system(show_tileset.system())
+		.add_startup_system(load_tileset)
+		.add_system(show_tileset)
 		.run();
 }
 
@@ -40,7 +40,6 @@ fn show_tileset(
 	tilesets: Tilesets,
 	mut commands: Commands,
 	my_tileset: Res<MyTileset>,
-	mut materials: ResMut<Assets<ColorMaterial>>,
 	mut has_ran: Local<bool>,
 ) {
 	if my_tileset.handle.is_none() || *has_ran || !tilesets.contains_name("My Awesome Tileset") {
@@ -63,7 +62,7 @@ fn show_tileset(
 		let texture = tileset.texture().clone();
 		commands.spawn_bundle(OrthographicCameraBundle::new_2d());
 		commands.spawn_bundle(SpriteBundle {
-			material: materials.add(texture.into()),
+			texture,
 			transform: Transform::from_xyz(0.0, 0.0, 0.0),
 			..Default::default()
 		});
@@ -78,7 +77,7 @@ fn show_tileset(
 							translation: Vec3::new(08.0, -48.0, 0.0),
 							..Default::default()
 						},
-						sprite: TextureAtlasSprite::new(*index as u32),
+						sprite: TextureAtlasSprite::new(*index),
 						texture_atlas: atlas.clone(),
 						..Default::default()
 					});


### PR DESCRIPTION
Update `bevy_tileset_tiles`, `bevy_tileset_core`, and `bevy_tileset` to support the Bevy 0.6 release.

Updates to `bevy_ecs_tilemap_tileset` will come in a separate PR as I also want to extract Auto Tiling and put most of the logic in the core crate.