### PR TITLE
Add Serialization/Deserialization

### DIFF
--- a/bevy_ecs_tilemap_tileset/Cargo.toml
+++ b/bevy_ecs_tilemap_tileset/Cargo.toml
@@ -8,21 +8,30 @@ repository = "https://github.com/MrGVSV/bevy_tileset"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy", "tileset", "auto", "variant", "tile"]
 categories = ["game-development"]
-readme = "../README.md"
+readme = "README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
 bevy_tileset = { path = "..", version = "0.2" }
 bevy = { version = "0.6", default-features = false }
 bevy_ecs_tilemap = "0.5"
-serde = "1.0"
+serde = { version = "1.0", optional = true }
+
+[dev-dependencies]
+serde_json = "1.0"
 
 [features]
 default = []
 variants = ["bevy_tileset/variants"]
 auto-tile = ["variants", "bevy_tileset/auto-tile"]
+serialization = ["serde"]
 
 [[example]]
 name = "clickable"
 path = "examples/clickable.rs"
-required-features = ["auto-tile", "bevy/default"]
+required-features = ["auto-tile", "bevy/default", "serialization"]
+
+[[example]]
+name = "serialization"
+path = "examples/serialization.rs"
+required-features = ["auto-tile", "bevy/default", "serialization"]

--- a/bevy_ecs_tilemap_tileset/README.md
+++ b/bevy_ecs_tilemap_tileset/README.md
@@ -79,7 +79,7 @@ fn load_maps(mut serializer: TilemapSerializer) {
 }
 ```
 
-To see this in action, check out the [serialization](https://github.com/MrGVSV/bevy_tileset/blob/main/bevy_ecs_tilemap_tileset/examples/serialization.rs) example, Again, as long as you set everything up using tilesets, it should work pretty much as expected.
+Check out the [serialization](https://github.com/MrGVSV/bevy_tileset/blob/main/bevy_ecs_tilemap_tileset/examples/serialization.rs) example to see how we turn some [JSON](https://github.com/MrGVSV/bevy_tileset/tree/main/bevy_ecs_tilemap_tileset/assets/map.json) into a full tilemap. Again, as long as you set everything up using tilesets, it should work pretty much as expected.
 
 ### 🧠 Auto Tiling
 

--- a/bevy_ecs_tilemap_tileset/README.md
+++ b/bevy_ecs_tilemap_tileset/README.md
@@ -1,0 +1,140 @@
+# bevy_ecs_tilemap_tileset
+
+An implementation of  [`bevy_tileset`](https://github.com/MrGVSV/bevy_tileset) for the [`bevy_ecs_tilemap`](https://github.com/StarArawn/bevy_ecs_tilemap) crate.
+
+<p align="center">
+	<img alt="Smart tile placement" src="https://github.com/MrGVSV/bevy_tileset/blob/770b45653fc8272921c1401d73f048406f3e2618/screenshots/tile_placement_demo.gif" />
+</p>
+
+## 📋 Features
+
+All features from `bevy_tileset`, including:
+
+- Define tilesets and tiles via [RON](https://github.com/ron-rs/ron) files
+- Load a tileset directly as a Bevy asset
+- Define Standard, Animated, Variant, and Auto tiles
+
+As well as features specific to this crate:
+
+* Super easy serialization and deserialization
+* Auto tiling support
+
+## 📲 Installation
+
+This crate is still not publicly released yet as I might want to make a PR to try and integrate it directly with `bevy_ecs_tilemap`, but for now you can use it with git:
+
+```toml
+[dependencies]
+bevy_ecs_tilemap_tileset = { git = "https://github.com/MrGVSV/bevy_tileset", version = "0.2" }
+```
+
+## ✨ Usage
+
+### 🧩 Tilesets
+
+For info on how to define and use tilesets, check out the [README](https://github.com/MrGVSV/bevy_tileset#-usage) for `bevy_tileset`. This crate re-exports the entire crate under the `tileset` submodule.
+
+To use it, make sure you add the following to your app:
+
+```rust
+fn main() {
+  App::new()
+    // ...
+    .add_plugin(TilesetPlugin)
+    // ...
+    .run();
+}
+```
+
+> **Note:** `TilesetPlugin` is an override of the one exported from `bevy_tileset`. Be sure to use the one from this crate!
+
+### 💾 Serialization/Deserialization
+
+> With the `serialization` feature enabled
+
+With this crate, serialization is very simple (as long as your tiles are generated using tilesets).
+
+Simply add the `TilemapSerializer` to your system:
+
+```rust
+/// Assumes bevy_ecs_tilemap has already been properly setup to have tiles read from it
+fn save_maps(serializer: TilemapSerializer) {
+  // This saves all currently generated maps
+  let maps = serializer.save_maps();
+  
+  // Write to disk using something like serde_json...
+}
+```
+
+And deserializing is just as simple:
+
+```rust
+/// Assumes bevy_ecs_tilemap has already been properly setup to have tiles placed into it
+fn load_maps(mut serializer: TilemapSerializer) {
+  let path = FileAssetIo::get_root_path().join("assets/map.json");
+	let data = std::fs::read_to_string(path).unwrap();
+	let maps = serde_json::from_str::<SerializableTilemap>(&data).unwrap();
+
+	serializer.load_maps(&maps);
+}
+```
+
+To see this in action, check out the [serialization](https://github.com/MrGVSV/bevy_tileset/blob/main/bevy_ecs_tilemap_tileset/examples/serialization.rs) example, Again, as long as you set everything up using tilesets, it should work pretty much as expected.
+
+### 🧠 Auto Tiling
+
+<p align="center">
+	<img alt="Auto tiling" src="https://github.com/MrGVSV/bevy_tileset/blob/b81d2d7483785e5aa58ef0b449482d9d57bca3be/screenshots/auto_tiling_demo.gif" />
+</p>
+
+While `bevy_tileset` adds the ability to define Auto Tiles, this crate actually puts it to use.
+
+If you use the `place_tile` function to place tiles from your tileset, then this should work automatically (mostly). If not, just be sure to add this when you spawn your tile:
+
+```rust
+let tile_id = ...
+commands.entity(tile_entity).insert(AutoTile::new(id.group_id, tile_id.tileset_id));
+```
+
+The `AutoTile` component acts as a marker, telling the auto tiling system that our tile is indeed an Auto Tile. And removing that component, removes it from the auto tiling system.
+
+> Remember that adding/removing the component is automatically handled when you place the tile down using `place_tile`.
+
+There are a few *annoying* things you'll have to be aware of, though— both of which relate to removing Auto Tiles.
+
+1. You need to ensure that any code that might remove an Auto Tile is put in the correct Stage and runs before `TilesetLabel::RemoveAutoTiles`:
+
+   ```rust
+   .add_system_to_stage(
+     TilesetStage,
+     my_tile_removal_system.before(TilesetLabel::RemoveAutoTiles),
+   )
+   ```
+
+   Failure to do this won't affect any other tile operation (including adding an Auto Tile). The only thing it affects is how the neighboring tiles are updated after removal.
+
+2. If you remove an Auto Tile, you also need to send a `RemoveAutoTileEvent` event:
+
+   ```rust
+   fn my_tile_removal_system(mut event_writer: EventWriter<RemoveAutoTileEvent>, /* ... */) {
+     // ...
+     if is_auto_tile {
+       event_writer.send(RemoveAutoTileEvent(tile_entity));
+     }
+   }
+   ```
+
+Other than that, though, it should be good to go! Just be careful with it. Auto tiles are slow, so thousands of them may result in lag when first placed (this can be mitigated by avoiding very large batch placements).
+
+## 🎓 Examples
+
+Check out the [examples](https://github.com/MrGVSV/bevy_tileset#-examples) for `bevy_tileset` for tileset-specific examples.
+
+* [clickable](bevy_ecs_tilemap_tileset/examples/clickable.rs) - Add and remove tiles using `bevy_ecs_tilemap` and `bevy_ecs_tilemap_tileset`
+*  [serialization](https://github.com/MrGVSV/bevy_tileset/blob/main/bevy_ecs_tilemap_tileset/examples/serialization.rs) - Load a tilemap from JSON
+
+## 🕊 Bevy Compatibility
+
+| bevy | bevy_tileset |
+| ---- | ------------ |
+| 0.5  | 0.2          |

--- a/bevy_ecs_tilemap_tileset/assets/map.json
+++ b/bevy_ecs_tilemap_tileset/assets/map.json
@@ -1,0 +1,730 @@
+{
+  "data": {
+    "0": {
+      "0": [
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 1,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            2
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 1,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            2
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 1,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            2
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 1,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            2
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 1,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            2
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 1,
+            "tileset_id": 0
+          },
+          "pos": [
+            14,
+            2
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 1,
+            "tileset_id": 0
+          },
+          "pos": [
+            8,
+            2
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 9,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            3
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            4
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 18,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            5
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            6
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 18,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            7
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            8
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 18,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            9
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 2,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            10
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 0,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            9
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 2,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            10
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 0,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            9
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 11,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            9
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 2,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            10
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 19,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            9
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            8
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 19,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            7
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            6
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 19,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            5
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            4
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 10,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            3
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 0,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            3
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 17,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            3
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 0,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            3
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            4
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 11,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            5
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 0,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            5
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 0,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            5
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            6
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 0,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            7
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 11,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            7
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 0,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            7
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 1,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            8
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 2,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            4
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 2,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            4
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 2,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            6
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 2,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            6
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 2,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            8
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 2,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            8
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 2,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            10
+          ]
+        },
+        {
+          "id": {
+            "auto_index": null,
+            "variant_index": null,
+            "group_id": 2,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            10
+          ]
+        }
+      ],
+      "1": [
+        {
+          "id": {
+            "auto_index": 5,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            8,
+            11
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 17,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            11
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 17,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            11
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 17,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            11
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 17,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            11
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 17,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            11
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 4,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            14,
+            11
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 12,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            9,
+            12
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 16,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            10,
+            12
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 16,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            12
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 16,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            12,
+            12
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 13,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            13,
+            12
+          ]
+        },
+        {
+          "id": {
+            "auto_index": 6,
+            "variant_index": 0,
+            "group_id": 4,
+            "tileset_id": 0
+          },
+          "pos": [
+            11,
+            3
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/bevy_ecs_tilemap_tileset/examples/helpers/input.rs
+++ b/bevy_ecs_tilemap_tileset/examples/helpers/input.rs
@@ -3,8 +3,10 @@ use bevy::math::Vec4Swizzles;
 use bevy::prelude::*;
 use bevy::render::camera::Camera;
 
+#[allow(dead_code)]
 pub struct ClickEvent(pub UVec2);
 
+#[allow(unused)]
 pub fn on_click(
 	query: Query<&Transform, With<WorldCamera>>,
 	wnds: Res<Windows>,

--- a/bevy_ecs_tilemap_tileset/examples/serialization.rs
+++ b/bevy_ecs_tilemap_tileset/examples/serialization.rs
@@ -1,0 +1,127 @@
+//! This example shows what loading a serialized tilemap might look like using the `TilemapSerializer`
+//! system parameter.
+
+use std::fs;
+
+use bevy::asset::{FileAssetIo, LoadState};
+use bevy::prelude::*;
+use bevy_ecs_tilemap::{ChunkSize, MapQuery, MapSize, TilemapLabel, TilemapPlugin};
+
+use bevy_ecs_tilemap_tileset::prelude::*;
+
+mod helpers;
+
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
+enum MapState {
+	LoadingTileset,
+	BuildingMap,
+	LoadingMap,
+}
+
+fn main() {
+	App::new()
+		// === Required === //
+		.add_plugins(DefaultPlugins)
+		.add_plugin(TilemapPlugin)
+		.add_plugin(TilesetPlugin)
+		// /== Required === //
+		// === Exmaple-Specific === //
+		.add_state(MapState::LoadingTileset)
+		.add_state_to_stage(CoreStage::PostUpdate, MapState::LoadingTileset)
+		.init_resource::<MyTileset>()
+		.add_system(helpers::set_texture_filters_to_nearest.label("helper"))
+		.add_system_set(
+			SystemSet::on_enter(MapState::LoadingTileset)
+				.with_system(load_tiles)
+				.after("helper"),
+		)
+		.add_system_set(
+			SystemSet::on_update(MapState::LoadingTileset).with_system(check_tiles_loaded),
+		)
+		.add_system_set(SystemSet::on_enter(MapState::BuildingMap).with_system(build_map))
+		.add_system_set(SystemSet::on_update(MapState::BuildingMap).with_system(can_load_maps))
+		.add_system_set(
+			SystemSet::on_enter(MapState::LoadingMap)
+				.with_system(load_maps)
+				.after(TilemapLabel::UpdateChunkMesh),
+		)
+		// /== Exmaple-Specific === //
+		.run();
+}
+
+#[derive(Default)]
+struct MyTileset {
+	/// This stores the handle to our tileset so it doesn't get unloaded
+	handle: Option<Handle<Tileset>>,
+}
+
+/// Starts the tileset loading process
+fn load_tiles(mut my_tileset: ResMut<MyTileset>, asset_server: Res<AssetServer>) {
+	my_tileset.handle = Some(asset_server.load("tilesets/my_tileset.ron"));
+}
+
+/// A system used to check the load state of the tileset
+fn check_tiles_loaded(
+	my_tileset: Res<MyTileset>,
+	asset_server: Res<AssetServer>,
+	mut state: ResMut<State<MapState>>,
+) {
+	if let Some(handle) = &my_tileset.handle {
+		if LoadState::Loaded == asset_server.get_load_state(handle) {
+			state.set(MapState::BuildingMap).unwrap();
+		}
+	}
+}
+
+/// A system used to build the tilemap
+fn build_map(
+	tilesets: Tilesets,
+	my_tileset: Res<MyTileset>,
+	mut commands: Commands,
+	mut map_query: MapQuery,
+) {
+	let handle = my_tileset.handle.as_ref().unwrap();
+	let tileset = tilesets.get(handle).unwrap();
+
+	// === Settings === //
+	let map_size = MapSize(4, 4);
+	let chunk_size = ChunkSize(5, 5);
+	let layer_count = 3;
+	let default_tile = match tileset.get_tile_index("Empty").unwrap() {
+		TileIndex::Standard(index) => index,
+		TileIndex::Animated(start, ..) => start,
+	} as u16;
+
+	// === Build === //
+	helpers::build_map(
+		tileset,
+		map_size,
+		chunk_size,
+		layer_count,
+		default_tile,
+		&mut commands,
+		&mut map_query,
+	);
+}
+
+/// Ensures that the tilemaps has been fully generated before loading the saved maps
+///
+/// This works by waiting a frame so that bevy_ecs_tilemap can get caught up and the Commands can be flushed
+fn can_load_maps(mut can_load: Local<bool>, mut state: ResMut<State<MapState>>) {
+	if *can_load {
+		state.set(MapState::LoadingMap).unwrap();
+	}
+	*can_load = true;
+}
+
+/// A system used to load the saved tilemaps from disk
+///
+/// The `TilemapSerializer` is a special system param that allows for entire tilemaps to be saved and loaded. Here,
+/// we are using it to load a JSON file containing our already saved data.
+fn load_maps(mut serializer: TilemapSerializer) {
+	let path = FileAssetIo::get_root_path().join("assets/map.json");
+	let data = fs::read_to_string(path).unwrap();
+	let maps = serde_json::from_str::<SerializableTilemap>(&data).unwrap();
+
+	serializer.load_maps(&maps);
+}

--- a/bevy_ecs_tilemap_tileset/src/auto/traits.rs
+++ b/bevy_ecs_tilemap_tileset/src/auto/traits.rs
@@ -1,5 +1,6 @@
+use crate::TileCoord;
 use bevy::math::IVec2;
-use bevy::prelude::{Entity, Query, UVec2, With};
+use bevy::prelude::{Entity, Query, With};
 use bevy_ecs_tilemap::{MapQuery, Tile, TileParent, TilePos};
 use bevy_tileset::auto::{AutoTile, AutoTileId};
 use std::cell::RefCell;
@@ -25,14 +26,6 @@ impl<'w, 's> TileQuery for Query<'w, 's, (Entity, &TilePos, &TileParent, &AutoTi
 	}
 }
 
-/// The corrdinates of the tile, including the `map_id` and `layer_id`
-#[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
-pub(super) struct TileCoord {
-	pub pos: TilePos,
-	pub map_id: u16,
-	pub layer_id: u16,
-}
-
 /// Defines a tile
 #[derive(Copy, Clone, Debug)]
 pub(super) struct TileInfo {
@@ -44,13 +37,6 @@ pub(super) struct TileInfo {
 pub(super) struct TilemapCache<'a, 'w, 's> {
 	pub tiles_query: &'a dyn TileQuery,
 	pub map_query: &'a RefCell<MapQuery<'w, 's>>,
-}
-
-impl bevy_tileset::auto::TileCoords for TileCoord {
-	fn pos(&self) -> IVec2 {
-		let pos: UVec2 = self.pos.into();
-		pos.as_ivec2()
-	}
 }
 
 impl TileInfo {

--- a/bevy_ecs_tilemap_tileset/src/lib.rs
+++ b/bevy_ecs_tilemap_tileset/src/lib.rs
@@ -1,9 +1,15 @@
+use bevy::math::{IVec2, UVec2};
+use bevy_ecs_tilemap::TilePos;
+
 pub use bevy_tileset as tileset;
+use bevy_tileset::tileset::coords::TileCoords;
 
 #[cfg(feature = "auto-tile")]
 pub(crate) mod auto;
 mod placement;
 mod plugin;
+#[cfg(feature = "serialization")]
+mod serialization;
 
 pub mod prelude {
 	pub use bevy_tileset::prelude::*;
@@ -12,4 +18,31 @@ pub mod prelude {
 	pub use super::auto::RemoveAutoTileEvent;
 	pub use super::placement::*;
 	pub use super::plugin::{TilesetLabel, TilesetPlugin, TilesetStage};
+	#[cfg(feature = "serialization")]
+	pub use super::serialization::*;
 }
+
+/// The corrdinates of the tile, including the `map_id` and `layer_id`
+#[derive(Copy, Clone, Debug, Default, Hash, Eq, PartialEq)]
+#[cfg_attr(
+	feature = "serialization",
+	derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct TileCoord {
+	#[cfg_attr(feature = "serialization", serde(with = "TilePosRef"))]
+	pub pos: TilePos,
+	pub map_id: u16,
+	pub layer_id: u16,
+}
+
+impl TileCoords for TileCoord {
+	fn pos(&self) -> IVec2 {
+		let pos: UVec2 = self.pos.into();
+		pos.as_ivec2()
+	}
+}
+
+#[cfg(feature = "serialization")]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(remote = "TilePos")]
+struct TilePosRef(pub u32, pub u32);

--- a/bevy_ecs_tilemap_tileset/src/serialization.rs
+++ b/bevy_ecs_tilemap_tileset/src/serialization.rs
@@ -1,0 +1,119 @@
+//! Tools for serializing and deserializing entire tilemaps with one or more tilesets
+
+use bevy::ecs::system::SystemParam;
+use bevy::prelude::{Commands, Query};
+use bevy::utils::{AHashExt, HashMap};
+use bevy_ecs_tilemap::{MapQuery, Tile, TileParent, TilePos};
+use serde::{Deserialize, Serialize};
+
+use bevy_tileset::prelude::{TileId, TilesetParent, Tilesets};
+
+use crate::placement::place_tile_by_id;
+
+/// Contains serializable tilemap data
+#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+pub struct SerializableTile {
+	pub id: TileId,
+	#[serde(with = "crate::TilePosRef")]
+	pub pos: TilePos,
+}
+
+/// Contains serializable tilemap data
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SerializableTilemap {
+	pub data: HashMap<u16, HashMap<u16, Vec<SerializableTile>>>,
+}
+
+/// A system parameter that can be used to handle tilemap serialization and deserialization
+#[derive(SystemParam)]
+pub struct TilemapSerializer<'w, 's> {
+	tiles: Query<
+		'w,
+		's,
+		(
+			&'static Tile,
+			&'static TileParent,
+			&'static TilePos,
+			&'static TilesetParent,
+		),
+	>,
+	commands: Commands<'w, 's>,
+	map_query: MapQuery<'w, 's>,
+	tilesets: Tilesets<'w, 's>,
+}
+
+macro_rules! save_tiles {
+	($self: ident, $tile: ident, $parent: ident, $pos: ident, $tileset: ident, $tiles_map: ident) => {
+		let tileset = $self.tilesets.get_by_id(&$tileset.0)?;
+		let index = $tile.texture_index as usize;
+		let tile_id = tileset.get_tile_id(&index)?;
+		let map = $tiles_map
+			.entry($parent.map_id)
+			.or_insert_with(HashMap::default);
+		let layer = map.entry($parent.layer_id).or_insert_with(Vec::default);
+		let tile = SerializableTile {
+			id: *tile_id,
+			pos: *$pos,
+		};
+		layer.push(tile);
+	};
+}
+
+impl<'w, 's> TilemapSerializer<'w, 's> {
+	/// Save all current maps
+	pub fn save_maps(&self) -> Option<SerializableTilemap> {
+		let capacity = self.tiles.iter().count();
+		let mut tiles_map = HashMap::with_capacity(capacity);
+		for (tile, parent, pos, tileset) in self.tiles.iter() {
+			save_tiles!(self, tile, parent, pos, tileset, tiles_map);
+		}
+		Some(SerializableTilemap { data: tiles_map })
+	}
+
+	/// Save the given map
+	pub fn save_map(&self, map_id: u16) -> Option<SerializableTilemap> {
+		let mut tiles_map = HashMap::default();
+		for (tile, parent, pos, tileset) in self.tiles.iter() {
+			if parent.map_id != map_id {
+				continue;
+			}
+
+			save_tiles!(self, tile, parent, pos, tileset, tiles_map);
+		}
+		Some(SerializableTilemap { data: tiles_map })
+	}
+
+	/// Save the given layer for the given map
+	pub fn save_layer(&self, map_id: u16, layer_id: u16) -> Option<SerializableTilemap> {
+		let mut tiles_map = HashMap::default();
+		for (tile, parent, pos, tileset) in self.tiles.iter() {
+			if parent.map_id != map_id || parent.layer_id != layer_id {
+				continue;
+			}
+
+			save_tiles!(self, tile, parent, pos, tileset, tiles_map);
+		}
+		Some(SerializableTilemap { data: tiles_map })
+	}
+
+	/// Load the given map
+	pub fn load_maps(&mut self, tilemap: &SerializableTilemap) {
+		for (map_id, layers) in &tilemap.data {
+			for (layer_id, tiles) in layers.iter() {
+				for tile in tiles {
+					if let Some(tileset) = self.tilesets.get_by_id(&tile.id.tileset_id) {
+						place_tile_by_id(
+							tile.id,
+							tileset,
+							tile.pos,
+							*map_id,
+							*layer_id,
+							&mut self.commands,
+							&mut self.map_query,
+						);
+					}
+				}
+			}
+		}
+	}
+}

--- a/bevy_tileset_core/src/auto/auto_tiler.rs
+++ b/bevy_tileset_core/src/auto/auto_tiler.rs
@@ -1,4 +1,5 @@
-use crate::auto::traits::{AutoTile, AutoTileRequest, AutoTilemap, TileCoords};
+use crate::auto::traits::{AutoTile, AutoTileRequest, AutoTilemap};
+use crate::coords::TileCoords;
 use bevy::math::IVec2;
 use bevy::utils::{HashMap, HashSet};
 use bevy_tileset_tiles::auto::AutoTileRule;

--- a/bevy_tileset_core/src/auto/mod.rs
+++ b/bevy_tileset_core/src/auto/mod.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::Component;
 
 pub use auto_tiler::AutoTiler;
-pub use traits::{AutoTile, AutoTileRequest, AutoTilemap, TileCoords};
+pub use traits::{AutoTile, AutoTileRequest, AutoTilemap};
 
 use crate::ids::{TileGroupId, TileId, TilesetId};
 

--- a/bevy_tileset_core/src/auto/traits.rs
+++ b/bevy_tileset_core/src/auto/traits.rs
@@ -1,4 +1,5 @@
 use crate::auto::AutoTileId;
+use crate::coords::TileCoords;
 use bevy::math::IVec2;
 use bevy_tileset_tiles::auto::AutoTileRule;
 use std::fmt::{Debug, Formatter};
@@ -19,18 +20,6 @@ impl<T: AutoTile + Debug> Debug for AutoTileRequest<T> {
 			.field("rule", &self.rule)
 			.finish()
 	}
-}
-
-/// A tile's coordinates
-///
-/// At minimum, this should be able to return a tile's position in the tilemap. However, it may also contain
-/// additional tile coordinate details such as layer index, chunk position, etc.
-pub trait TileCoords {
-	/// The tile position on the map
-	///
-	/// This is __not__ a tile's position in its chunk. It must be the actual integer coordinates of the tile's
-	/// tilemap position.
-	fn pos(&self) -> IVec2;
 }
 
 /// A trait containing Auto Tile data

--- a/bevy_tileset_core/src/coords.rs
+++ b/bevy_tileset_core/src/coords.rs
@@ -1,0 +1,13 @@
+use bevy::math::IVec2;
+
+/// A tile's coordinates
+///
+/// At minimum, this should be able to return a tile's position in the tilemap. However, it may also contain
+/// additional tile coordinate details such as layer index, chunk position, etc.
+pub trait TileCoords {
+	/// The tile position on the map
+	///
+	/// This is __not__ a tile's position in its chunk. It must be the actual integer coordinates of the tile's
+	/// tilemap position.
+	fn pos(&self) -> IVec2;
+}

--- a/bevy_tileset_core/src/lib.rs
+++ b/bevy_tileset_core/src/lib.rs
@@ -5,6 +5,7 @@ mod tileset;
 
 #[cfg(feature = "auto-tile")]
 pub mod auto;
+pub mod coords;
 
 /// A collection of commonly used modules (import via `bevy_tileset_core::prelude::*`)
 pub mod prelude {


### PR DESCRIPTION
Adds serialization and deserialization support to `bevy_ecs_tilemap_tileset`. This is done through the new `TilemapSerializer` system parameter.

## Saving

```rust
/// Assumes bevy_ecs_tilemap has already been properly setup to have tiles read from it
fn save_maps(serializer: TilemapSerializer) {
  // This saves all currently generated maps
  let maps = serializer.save_maps();
  
  // Write to disk using something like serde_json...
}
```

## Loading

```rust
/// Assumes bevy_ecs_tilemap has already been properly setup to have tiles placed into it
fn load_maps(mut serializer: TilemapSerializer) {
  let path = FileAssetIo::get_root_path().join("assets/map.json");
  let data = std::fs::read_to_string(path).unwrap();
  let maps = serde_json::from_str::<SerializableTilemap>(&data).unwrap();

  serializer.load_maps(&maps);
}
```