### PR TITLE
Make `new` methods const on `TileId` and `PartialTileId`

### DIFF
--- a/bevy_tileset_core/src/ids.rs
+++ b/bevy_tileset_core/src/ids.rs
@@ -43,7 +43,7 @@ pub struct PartialTileId {
 
 impl TileId {
 	/// Create a new basic tile ID
-	pub fn new(group_id: TileGroupId, tileset_id: TilesetId) -> Self {
+	pub const fn new(group_id: TileGroupId, tileset_id: TilesetId) -> Self {
 		Self {
 			#[cfg(feature = "auto-tile")]
 			auto_index: None,
@@ -89,7 +89,7 @@ impl TileId {
 }
 
 impl PartialTileId {
-	pub fn new(group_id: TileGroupId) -> Self {
+	pub const fn new(group_id: TileGroupId) -> Self {
 		Self {
 			#[cfg(feature = "auto-tile")]
 			auto_index: None,


### PR DESCRIPTION
The main reason for this is to allow IDs be declared as constants without having to write out the full struct:

```rust
const MY_ID: TileId = TileId {
  group_id: 1,
  tileset_id: 5,
  auto_index: None,
  variant_index: None,
};
```

Which can be dangerous since `auto_index` and `variant_index` only exist with certain features enabled. It's also overkill if you just need to define the tile group and tileset. In which case, this new method is much simpler:

```rust
const MY_ID: TileId = TileId::new(1, 5);
```