### PR TITLE
Update to Bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.3" }
 bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.3" }
 
 [dev-dependencies]
-bevy = "0.6"
+bevy = "0.7"
 ron = "0.7"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Simple, configurable tilesets in Bevy using RON"
@@ -15,8 +15,8 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 members = ["bevy_tileset_core", "bevy_tileset_tiles"]
 
 [dependencies]
-bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.3" }
-bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.3" }
+bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.4" }
+bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.4" }
 
 [dev-dependencies]
 bevy = "0.7"

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Add one of the following lines to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-bevy_tileset_tiles = "0.3" # For the base tile definitions
-bevy_tileset = "0.3" # For general tileset usage (includes above)
+bevy_tileset_tiles = "0.4" # For the base tile definitions
+bevy_tileset = "0.4" # For general tileset usage (includes above)
 ```
 
 ## ✨ Usage
@@ -229,7 +229,8 @@ These tiles are defined with the [`bevy_ecs_tilemap`](https://github.com/StarAra
 ## 🕊 Bevy Compatibility
 
 | bevy | bevy_tileset |
-| ---- | ------------ |
+|------|--------------|
+| 0.7  | 0.4          |
 | 0.6  | 0.3          |
 | 0.5  | 0.2          |
 

--- a/bevy_tileset_core/Cargo.toml
+++ b/bevy_tileset_core/Cargo.toml
@@ -13,8 +13,8 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
 bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.3" }
-bevy = { version = "0.6", default-features = false, features = ["render", "png"] }
-bevy_tile_atlas = "0.2"
+bevy = { version = "0.7", default-features = false, features = ["render", "png"] }
+bevy_tile_atlas = "0.3"
 ron = "0.7.0"
 serde = "1.0"
 anyhow = "1.0"

--- a/bevy_tileset_core/Cargo.toml
+++ b/bevy_tileset_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset_core"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Core of bevy_tileset"
@@ -12,7 +12,7 @@ readme = "../README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
-bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.3" }
+bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.4" }
 bevy = { version = "0.7", default-features = false, features = ["render", "png"] }
 bevy_tile_atlas = "0.3"
 ron = "0.7.0"

--- a/bevy_tileset_tiles/Cargo.toml
+++ b/bevy_tileset_tiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset_tiles"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Tile definitions used by bevy_tileset"

--- a/bevy_tileset_tiles/Cargo.toml
+++ b/bevy_tileset_tiles/Cargo.toml
@@ -12,8 +12,8 @@ readme = "../README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
-bevy_render = { version = "0.6", default-features = false }
-bevy_asset = { version = "0.6", default-features = false }
+bevy_render = { version = "0.7", default-features = false }
+bevy_asset = { version = "0.7", default-features = false }
 serde = "1.0"
 
 [features]


### PR DESCRIPTION
Update `bevy_tileset_tiles`, `bevy_tileset_core`, and `bevy_tileset` to support the Bevy 0.7 release.