### PR TITLE
Update to Bevy 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset"
-version = "0.6.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Simple, configurable tilesets in Bevy using RON"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Simple, configurable tilesets in Bevy using RON"
@@ -15,11 +15,11 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 members = ["bevy_tileset_core", "bevy_tileset_tiles"]
 
 [dependencies]
-bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.5" }
-bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.5" }
+bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.6" }
+bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.6" }
 
 [dev-dependencies]
-bevy = "0.8"
+bevy = "0.9"
 ron = "0.7"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 members = ["bevy_tileset_core", "bevy_tileset_tiles"]
 
 [dependencies]
-bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.6" }
-bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.6" }
+bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.5" }
+bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.5" }
 
 [dev-dependencies]
 bevy = "0.9"

--- a/bevy_tileset_core/Cargo.toml
+++ b/bevy_tileset_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset_core"
-version = "0.6.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Core of bevy_tileset"
@@ -12,7 +12,7 @@ readme = "../README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
-bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.6" }
+bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.5" }
 bevy = { version = "0.9", default-features = false, features = ["render", "png", "bevy_asset"] }
 bevy_tile_atlas = "0.5"
 ron = "0.7.0"

--- a/bevy_tileset_core/Cargo.toml
+++ b/bevy_tileset_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset_core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Core of bevy_tileset"
@@ -12,9 +12,9 @@ readme = "../README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
-bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.5" }
-bevy = { version = "0.8", default-features = false, features = ["render", "png", "bevy_asset"] }
-bevy_tile_atlas = "0.4"
+bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.6" }
+bevy = { version = "0.9", default-features = false, features = ["render", "png", "bevy_asset"] }
+bevy_tile_atlas = "0.5"
 ron = "0.7.0"
 serde = "1.0"
 anyhow = "1.0"

--- a/bevy_tileset_core/src/debug.rs
+++ b/bevy_tileset_core/src/debug.rs
@@ -101,7 +101,7 @@ fn display_tilesets(state: DebugState) -> impl FnMut(Local<bool>, Tilesets, Comm
 
 		let mut spawner = |tileset: &Tileset| {
 			commands
-				.spawn_bundle(SpriteBundle {
+				.spawn(SpriteBundle {
 					texture: tileset.texture().clone(),
 					transform: Transform::from_translation(state.position + offset),
 					..Default::default()

--- a/bevy_tileset_core/src/tileset/asset.rs
+++ b/bevy_tileset_core/src/tileset/asset.rs
@@ -55,7 +55,7 @@ impl<'x, 'y> TextureLoader for TilesetTextureLoader<'x, 'y> {
 		let path = asset_path.path().to_path_buf();
 
 		if let Ok(mut images) = self.bytes.try_write() {
-			images.insert(handle.id, path);
+			images.insert(handle.id(), path);
 		}
 		handle
 	}

--- a/bevy_tileset_core/src/tileset/param.rs
+++ b/bevy_tileset_core/src/tileset/param.rs
@@ -1,7 +1,7 @@
 use crate::prelude::{Tileset, TilesetId};
 use bevy::asset::{Assets, Handle};
 use bevy::ecs::system::SystemParam;
-use bevy::prelude::{Query, Res};
+use bevy::prelude::{Query, Res, Resource};
 use std::collections::HashMap;
 use std::ops::Deref;
 
@@ -15,7 +15,7 @@ pub struct Tilesets<'w, 's> {
 	phantom_query: Query<'w, 's, ()>,
 }
 
-#[derive(Default)]
+#[derive(Resource, Default)]
 pub struct TilesetMap {
 	name_to_id: HashMap<String, TilesetId>,
 	id_to_handle: HashMap<TilesetId, Handle<Tileset>>,

--- a/bevy_tileset_tiles/Cargo.toml
+++ b/bevy_tileset_tiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset_tiles"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Tile definitions used by bevy_tileset"
@@ -12,8 +12,8 @@ readme = "../README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
-bevy_render = { version = "0.8", default-features = false }
-bevy_asset = { version = "0.8", default-features = false }
+bevy_render = { version = "0.9", default-features = false }
+bevy_asset = { version = "0.9", default-features = false }
 serde = "1.0"
 
 [features]

--- a/bevy_tileset_tiles/Cargo.toml
+++ b/bevy_tileset_tiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset_tiles"
-version = "0.6.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Tile definitions used by bevy_tileset"

--- a/bevy_tileset_tiles/src/tile.rs
+++ b/bevy_tileset_tiles/src/tile.rs
@@ -194,7 +194,7 @@ impl TileHandle {
 	}
 
 	pub fn get_load_state(&self, asset_server: &AssetServer) -> LoadState {
-		asset_server.get_group_load_state(self.iter_handles().map(|handle| handle.id))
+		asset_server.get_group_load_state(self.iter_handles().map(|handle| handle.id()))
 	}
 
 	pub fn iter_handles(&self) -> Box<dyn Iterator<Item = &Handle<Image>> + '_> {

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -28,6 +28,7 @@ fn main() {
 		.run();
 }
 
+#[derive(Resource)]
 struct MyTileset {
 	/// This stores the handle to our tileset so it doesn't get unloaded
 	tiles: Option<Vec<TileHandle>>,
@@ -134,8 +135,8 @@ fn show_tileset(
 
 	// === Display Tileset === //
 	let texture = raw_tileset.texture().clone();
-	commands.spawn_bundle(Camera2dBundle::default());
-	commands.spawn_bundle(SpriteBundle {
+	commands.spawn(Camera2dBundle::default());
+	commands.spawn(SpriteBundle {
 		texture,
 		transform: Transform::from_xyz(0.0, 0.0, 0.0),
 		..Default::default()
@@ -150,7 +151,7 @@ fn show_tileset(
 					let mut texture = handle.clone();
 					// Handles in the tileset are weak by default so we'll need to make it strong again so the image doesn't unload
 					texture.make_strong(&mut textures);
-					commands.spawn_bundle(SpriteBundle {
+					commands.spawn(SpriteBundle {
 						texture,
 						transform: Transform::from_xyz(0.0, 48.0, 0.0),
 						..Default::default()

--- a/examples/tileset.rs
+++ b/examples/tileset.rs
@@ -21,7 +21,7 @@ fn main() {
 		.run();
 }
 
-#[derive(Default)]
+#[derive(Resource, Default)]
 struct MyTileset {
 	/// This stores the handle to our tileset so it doesn't get unloaded
 	handle: Option<Handle<Tileset>>,
@@ -60,8 +60,8 @@ fn show_tileset(
 		// === Display Tileset === //
 		let atlas = tileset.atlas();
 		let texture = tileset.texture().clone();
-		commands.spawn_bundle(Camera2dBundle::default());
-		commands.spawn_bundle(SpriteBundle {
+		commands.spawn(Camera2dBundle::default());
+		commands.spawn(SpriteBundle {
 			texture,
 			transform: Transform::from_xyz(0.0, 0.0, 0.0),
 			..Default::default()
@@ -72,7 +72,7 @@ fn show_tileset(
 			match tile_index {
 				TileIndex::Standard(index) => {
 					// Do something standard
-					commands.spawn_bundle(SpriteSheetBundle {
+					commands.spawn(SpriteSheetBundle {
 						transform: Transform {
 							translation: Vec3::new(08.0, -48.0, 0.0),
 							..Default::default()
@@ -81,10 +81,10 @@ fn show_tileset(
 						texture_atlas: atlas.clone(),
 						..Default::default()
 					});
-				}
+				},
 				TileIndex::Animated(start, end, speed) => {
 					// Do something  ✨ animated ✨
-				}
+				},
 			}
 		}
 


### PR DESCRIPTION
Quick and simple update to Bevy 0.9.
Depends on the bevy_tile_atlas 0.5 PR I opened in your other repo. (I tested it using a git tag in cargo.toml)
Adds Resource derives, uses spawn instead of spawn_bundle and uses handle.id() instead of accessing the field directly.