### PR TITLE
WIP migrate to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 members = ["bevy_tileset_core", "bevy_tileset_tiles"]
 
 [dependencies]
-bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.8" }
-bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.8" }
+bevy_tileset_tiles = { path = "./bevy_tileset_tiles", version = "0.9" }
+bevy_tileset_core = { path = "./bevy_tileset_core", version = "0.9" }
 
 [dev-dependencies]
-bevy = "0.11"
+bevy = "0.12"
 ron = "0.8"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Add one of the following lines to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-bevy_tileset_tiles = "0.8" # For the base tile definitions
-bevy_tileset = "0.8" # For general tileset usage (includes above)
+bevy_tileset_tiles = "0.9" # For the base tile definitions
+bevy_tileset = "0.9" # For general tileset usage (includes above)
 ```
 
 ## ✨ Usage
@@ -239,6 +239,7 @@ texture atlas). Other solutions may need to be adapted in order to work with thi
 
 | bevy | bevy_tileset |
 |------|--------------|
+| 0.12 | 0.9          |
 | 0.11 | 0.8          |
 | 0.10 | 0.7          |
 | 0.9  | 0.6          |

--- a/bevy_tileset_core/Cargo.toml
+++ b/bevy_tileset_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset_core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Core of bevy_tileset"
@@ -12,9 +12,9 @@ readme = "../README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
-bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.8" }
-bevy = { version = "0.11", default-features = false, features = ["bevy_render", "png", "bevy_asset", "bevy_sprite"] }
-bevy_tile_atlas = { path = "../../bevy_tile_atlas", version = "0.7" }
+bevy_tileset_tiles = { path = "../bevy_tileset_tiles", version = "0.9" }
+bevy = { version = "0.12", default-features = false, features = ["bevy_render", "png", "bevy_asset", "bevy_sprite"] }
+bevy_tile_atlas = { path = "../../bevy_tile_atlas", version = "0.8" }
 ron = "0.8.0"
 serde = "1.0"
 anyhow = "1.0"

--- a/bevy_tileset_core/src/plugin.rs
+++ b/bevy_tileset_core/src/plugin.rs
@@ -7,8 +7,8 @@ pub struct TilesetPlugin {}
 
 impl Plugin for TilesetPlugin {
 	fn build(&self, app: &mut App) {
-		app.add_asset::<Tileset>()
-			.init_asset_loader::<TilesetAssetLoader>()
+		app.init_asset_loader::<TilesetAssetLoader>()
+			.init_asset::<Tileset>()
 			.init_resource::<TilesetMap>()
 			.add_systems(Update, tileset_event_sys);
 	}
@@ -19,16 +19,21 @@ fn tileset_event_sys(
 	mut event_reader: EventReader<AssetEvent<Tileset>>,
 	mut map: ResMut<TilesetMap>,
 	tilesets: Res<Assets<Tileset>>,
+	asset_server: ResMut<AssetServer>,
 ) {
-	for event in event_reader.iter() {
+	for event in event_reader.read() {
 		match event {
-			AssetEvent::<Tileset>::Created { handle } => {
-				if let Some(tileset) = tilesets.get(handle) {
-					map.register_tileset(tileset, &handle);
+			AssetEvent::<Tileset>::Added { id } => {
+				if let Some(handle) = asset_server.get_id_handle(*id) {
+					if let Some(tileset) = tilesets.get(handle.clone()) {
+						map.register_tileset(tileset, &handle);
+					}
 				}
 			},
-			AssetEvent::<Tileset>::Removed { handle } => {
-				map.deregister_tileset(&handle);
+			AssetEvent::<Tileset>::Removed { id } => {
+				if let Some(handle) = asset_server.get_id_handle(*id) {
+					map.deregister_tileset(&handle);
+				}
 			},
 			_ => {},
 		}

--- a/bevy_tileset_core/src/tileset/asset.rs
+++ b/bevy_tileset_core/src/tileset/asset.rs
@@ -1,20 +1,35 @@
-use std::collections::{BTreeMap, HashMap};
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
-
-use bevy::asset::{
-	Asset, AssetLoader, AssetPath, BoxedFuture, Handle, HandleId, LoadContext, LoadedAsset,
+use std::{
+	collections::{BTreeMap, HashMap},
+	path::{Path, PathBuf},
+	sync::{Arc, RwLock},
 };
-use bevy::prelude::{FromWorld, World};
-use bevy::render::renderer::RenderDevice;
-use bevy::render::texture::{CompressedImageFormats, Image, ImageType};
-use bevy::utils::Uuid;
+
+use bevy::{
+	asset::{
+		io::Reader,
+		Asset,
+		AssetLoader,
+		AssetPath,
+		AsyncReadExt,
+		BoxedFuture,
+		Handle,
+		LoadContext,
+	},
+	prelude::{AssetId, FromWorld, World},
+	render::{
+		renderer::RenderDevice,
+		texture::{CompressedImageFormats, Image, ImageSampler, ImageType},
+	},
+	utils::Uuid,
+};
 use bevy_tile_atlas::TextureStore;
 use bevy_tileset_tiles::prelude::{TileDef, TileHandle};
 use serde::{Deserialize, Serialize};
 
-use crate::prelude::{TileGroupId, Tileset, TilesetBuilder, TilesetError, TilesetId};
-use crate::tileset::load::{load_tile_handles, TextureLoader};
+use crate::{
+	prelude::{TileGroupId, Tileset, TilesetBuilder, TilesetError, TilesetId},
+	tileset::load::{load_tile_handles, TextureLoader},
+};
 
 pub struct TilesetAssetLoader {
 	supported_compressed_formats: CompressedImageFormats,
@@ -39,20 +54,24 @@ struct TilesetTextureLoader<'x, 'y> {
 	supported_compressed_formats: CompressedImageFormats,
 	load_context: &'x mut LoadContext<'y>,
 	/// The images that need to be loaded
-	bytes: Arc<RwLock<HashMap<HandleId, PathBuf>>>,
+	bytes: Arc<RwLock<HashMap<AssetId<Image>, PathBuf>>>,
 }
 
 /// A struct that mimics a Bevy `Assets<Texture>` resource by allowing get/add operations
 struct TilesetTextureStore<'x, 'y> {
 	load_context: &'x mut LoadContext<'y>,
-	images: HashMap<HandleId, Image>,
+	images: HashMap<Handle<Image>, Image>,
 }
 
 impl<'x, 'y> TextureLoader for TilesetTextureLoader<'x, 'y> {
-	fn load_texture<'a, T: Asset, P: Into<AssetPath<'a>>>(&self, path: P) -> Handle<Image> {
-		let asset_path = path.into().clone();
-		let handle: Handle<Image> = self.load_context.get_handle(asset_path.clone());
-		let path = asset_path.path().to_path_buf();
+	fn load_texture<'a, T: Asset, P: Into<AssetPath<'a>>>(&mut self, path: P) -> Handle<Image> {
+		let asset_path: AssetPath = path.into();
+		let handle: Handle<Image> = self
+			.load_context
+			// FIXME unwrap
+			.get_label_handle(asset_path.clone().to_string());
+		let asset_path = asset_path.path();
+		let path = asset_path.to_path_buf();
 
 		if let Ok(mut images) = self.bytes.try_write() {
 			images.insert(handle.id(), path);
@@ -61,14 +80,17 @@ impl<'x, 'y> TextureLoader for TilesetTextureLoader<'x, 'y> {
 	}
 }
 
+/*
 impl<'x, 'y> TilesetTextureLoader<'x, 'y> {
 	/// Load the images and collect them into a HashMap
-	fn collect_images(self) -> BoxedFuture<'x, Result<HashMap<HandleId, Image>, TilesetError>> {
+	fn collect_images(
+		mut self,
+	) -> BoxedFuture<'x, Result<HashMap<AssetId<Image>, Image>, TilesetError>> {
 		let images = self.bytes.read().unwrap().clone();
 		Box::pin(async move {
 			let image_map = futures::future::join_all(images.into_iter().map(|(id, path)| {
 				load_image(
-					&self.load_context,
+					&mut self.load_context,
 					id,
 					path,
 					self.supported_compressed_formats,
@@ -83,6 +105,7 @@ impl<'x, 'y> TilesetTextureLoader<'x, 'y> {
 		})
 	}
 }
+	*/
 
 impl<'x, 'y> TextureStore for TilesetTextureStore<'x, 'y> {
 	fn add(&mut self, asset: Image) -> Handle<Image> {
@@ -94,11 +117,10 @@ impl<'x, 'y> TextureStore for TilesetTextureStore<'x, 'y> {
 			.to_str()
 			.unwrap_or("UNKNOWN_TILESET");
 		let label = format!("Tileset__[{:?}]__{:?}", prefix, Uuid::new_v4().to_string());
-		self.load_context
-			.set_labeled_asset(&label, LoadedAsset::new(asset))
+		self.load_context.add_labeled_asset(label, asset)
 	}
 
-	fn get<H: Into<HandleId>>(&self, handle: H) -> Option<&Image> {
+	fn get<H: Into<Handle<Image>>>(&self, handle: H) -> Option<&Image> {
 		self.images.get(&handle.into())
 	}
 }
@@ -117,25 +139,70 @@ impl FromWorld for TilesetAssetLoader {
 }
 
 impl AssetLoader for TilesetAssetLoader {
+	type Asset = Tileset;
+	type Settings = ();
+	type Error = TilesetError;
+
 	fn load<'a>(
 		&'a self,
-		bytes: &'a [u8],
+		reader: &'a mut Reader,
+		_settings: &'a Self::Settings,
 		load_context: &'a mut LoadContext,
-	) -> BoxedFuture<'a, anyhow::Result<(), anyhow::Error>> {
+	) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
 		Box::pin(async move {
-			let config = ron::de::from_bytes::<TilesetDef>(bytes)?;
+			let mut bytes = Vec::new();
+			reader.read_to_end(&mut bytes).await?;
+
+			let definition = ron::de::from_bytes::<TilesetDef>(&bytes)?;
 
 			// === Load Handles === //
-			let loader = TilesetTextureLoader {
+			let mut loader = TilesetTextureLoader {
 				supported_compressed_formats: self.supported_compressed_formats,
 				bytes: Arc::new(RwLock::new(HashMap::new())),
 				load_context,
 			};
 
-			let tile_handles = get_tile_handles(&loader, &config.tiles).await?;
+			// FIXME
+			let mut tile_defs: Vec<TileDef> = vec![];
+			for (.., tile_path) in definition.tiles.iter() {
+				let path = tile_path;
+				let path = if let Some(parent) = loader.load_context.path().parent() {
+					parent.join(path)
+				} else {
+					Path::new(&path).to_path_buf()
+				};
+				let bytes = loader
+					.load_context
+					.read_asset_bytes(path)
+					.await
+					.map_err(|err| TilesetError::ReadAssetBytesError(err))?;
+				let def = ron::de::from_bytes::<TileDef>(&bytes)
+					.map_err(|err| TilesetError::InvalidDefinition(err))?;
+				tile_defs.push(def);
+			}
+			let handles = load_tile_handles(tile_defs, &mut loader);
+			let tile_handles: Vec<(TileGroupId, TileHandle)> = definition
+				.tiles
+				.iter()
+				.map(|(id, ..)| *id)
+				.zip(handles.into_iter().map(|handle| handle))
+				.collect();
 
 			// === Build Tiles === //
-			let images = loader.collect_images().await?;
+			//let images = loader.collect_images().await?;
+			let images = loader.bytes.read().unwrap().clone();
+			let mut image_map = vec![];
+			for (id, path) in images.into_iter() {
+				let image =
+					load_image(load_context, id, path, self.supported_compressed_formats).await;
+				image_map.push(image);
+			}
+			let images = image_map
+				.into_iter()
+				.filter_map(|x| x.ok())
+				// TODO not sure about the Weak Handle here
+				.map(|(asset_id, image)| (Handle::Weak(asset_id), image))
+				.collect();
 			let mut store = TilesetTextureStore {
 				load_context,
 				images,
@@ -147,15 +214,14 @@ impl AssetLoader for TilesetAssetLoader {
 			}
 
 			// === Create Raw Tileset === //
-			let name = config
+			let name = definition
 				.name
 				.unwrap_or_else(|| Uuid::new_v4().hyphenated().to_string());
-			let raw_tileset = builder.build(name, config.id, &mut store)?;
+			let raw_tileset = builder.build(name, definition.id, &mut store)?;
 
 			// === Finalize Tileset === //
 			let texture = raw_tileset.atlas().texture.clone();
-			let atlas_asset = LoadedAsset::new(raw_tileset.atlas);
-			let atlas = load_context.set_labeled_asset("atlas", atlas_asset);
+			let atlas = load_context.add_labeled_asset("atlas".to_owned(), raw_tileset.atlas);
 			let tileset = Tileset {
 				id: raw_tileset.id,
 				name: raw_tileset.name,
@@ -170,33 +236,61 @@ impl AssetLoader for TilesetAssetLoader {
 				texture,
 			};
 
-			load_context.set_default_asset(LoadedAsset::new(tileset));
-
-			Ok(())
+			Ok(tileset)
 		})
 	}
 
-	fn extensions(&self) -> &[&str] {
-		&["ron"]
-	}
+	fn extensions(&self) -> &[&str] { &["ron"] }
 }
 
+/*
 /// Get a `Vec` of ([`TileGroupId`], [`TileHandle`]) tuples
 async fn get_tile_handles<'x, 'y>(
-	loader: &'x TilesetTextureLoader<'x, 'y>,
+	loader: &'x mut TilesetTextureLoader<'x, 'y>,
 	tile_paths: &BTreeMap<TileGroupId, String>,
 ) -> Result<Vec<(TileGroupId, TileHandle)>, TilesetError> {
+	IoTaskPool::get()
+		.scope(|scope| {
+			let bytes = tile_paths.iter().map(|(.., tile_path)| {
+				let path = tile_path;
+				let path = if let Some(parent) = loader.load_context.path().parent() {
+					parent.join(path)
+				} else {
+					Path::new(path).to_path_buf()
+				};
+				loader.load_context.read_asset_bytes(path)
+			});
+
+			for bytes in bytes {
+				scope.spawn(async move {
+					let bytes = bytes
+						.await
+						.map_err(|err| TilesetError::ReadAssetBytesError(err))?;
+					let def = ron::de::from_bytes::<TileDef>(&bytes)
+						.map_err(|err| TilesetError::InvalidDefinition(err))?;
+					Ok(def)
+				});
+			}
+		})
+		.into_iter()
+		.filter_map(|tile_def: Result<TileDef, TilesetError>| tile_def.ok())
+		.collect::<Vec<_>>();
+	/*
 	let tile_defs = futures::future::join_all(
 		tile_paths
 			.iter()
-			.map(|(.., tile_path)| load_tile(&loader.load_context, tile_path)),
+			.map(|(.., tile_path)| load_tile(&mut loader.load_context, tile_path)),
 	)
 	.await
 	.into_iter()
 	.filter_map(|tile_def| tile_def.ok())
 	.collect::<Vec<_>>();
+	*/
+	// FIXME
+	//let tile_defs = vec![];
 
-	let handles = load_tile_handles(tile_defs, loader);
+	//let handles = load_tile_handles(tile_defs, loader);
+	let handles = vec![];
 
 	Ok(tile_paths
 		.iter()
@@ -204,36 +298,34 @@ async fn get_tile_handles<'x, 'y>(
 		.zip(handles.into_iter().map(|handle| handle))
 		.collect())
 }
+	*/
 
 /// Load the tile definition at the given path and return its corresponding [TileDef]
 ///
 /// The path is always relative to the tileset's configuration file path
-async fn load_tile(context: &LoadContext<'_>, path: &str) -> Result<TileDef, TilesetError> {
-	let path = if let Some(parent) = context.path().parent() {
-		parent.join(path)
-	} else {
-		Path::new(path).to_path_buf()
-	};
+/*
+async fn load_tile<'x>(context: &mut LoadContext<'x>, path: &str) -> Result<TileDef, TilesetError> {
 	let bytes = context
-		.read_asset_bytes(&path)
+		.read_asset_bytes(path)
 		.await
-		.map_err(|err| TilesetError::AssetIoError(err))?;
+		.map_err(|err| TilesetError::ReadAssetBytesError(err))?;
 	let def = ron::de::from_bytes::<TileDef>(&bytes)
 		.map_err(|err| TilesetError::InvalidDefinition(err))?;
 	Ok(def)
 }
+*/
 
 /// Load an image at the given path
 async fn load_image(
-	context: &LoadContext<'_>,
-	id: HandleId,
+	context: &mut LoadContext<'_>,
+	id: AssetId<Image>,
 	path: PathBuf,
 	supported_compressed_formats: CompressedImageFormats,
-) -> Result<(HandleId, Image), TilesetError> {
+) -> Result<(AssetId<Image>, Image), TilesetError> {
 	let bytes = context
 		.read_asset_bytes(path.clone())
 		.await
-		.map_err(|err| TilesetError::AssetIoError(err))?;
+		.map_err(|err| TilesetError::ReadAssetBytesError(err))?;
 	let path = path.as_path();
 	let ext = path.extension().unwrap().to_str().unwrap();
 	let img = Image::from_buffer(
@@ -241,6 +333,7 @@ async fn load_image(
 		ImageType::Extension(ext),
 		supported_compressed_formats,
 		true,
+		ImageSampler::default(),
 	)
 	.map_err(|err| TilesetError::ImageError(err))?;
 	Ok((id, img))

--- a/bevy_tileset_core/src/tileset/builder.rs
+++ b/bevy_tileset_core/src/tileset/builder.rs
@@ -1,5 +1,4 @@
-use crate::ids::PartialTileId;
-use crate::prelude::*;
+use crate::{ids::PartialTileId, prelude::*};
 use bevy::prelude::{Handle, Image};
 use bevy_tile_atlas::{TextureStore, TileAtlasBuilder, TileAtlasBuilderError};
 use bevy_tileset_tiles::prelude::*;
@@ -140,14 +139,14 @@ impl TilesetBuilder {
 		Ok(match tile {
 			TileHandleType::Standard(handle) => {
 				TileType::Standard(self.insert_handle(&handle, texture_store)?)
-			}
+			},
 			TileHandleType::Animated(anim) => {
 				TileType::Animated(self.create_animated(anim, texture_store)?)
-			}
+			},
 			#[cfg(feature = "variants")]
 			TileHandleType::Variant(variants) => {
 				TileType::Variant(self.create_variants(variants, texture_store)?)
-			}
+			},
 			#[cfg(feature = "auto-tile")]
 			TileHandleType::Auto(autos) => TileType::Auto(self.create_autos(autos, texture_store)?),
 		})
@@ -191,10 +190,10 @@ impl TilesetBuilder {
 					match variant.tile {
 						SimpleTileHandle::Standard(handle) => {
 							SimpleTileType::Standard(self.insert_handle(&handle, texture_store)?)
-						}
+						},
 						SimpleTileHandle::Animated(anim) => {
 							SimpleTileType::Animated(self.create_animated(anim, texture_store)?)
-						}
+						},
 					},
 				);
 				self.current_variant = Some(1 + self.current_variant.unwrap_or(0));
@@ -240,7 +239,7 @@ impl TilesetBuilder {
 		handle: &Handle<Image>,
 		textures: &TStore,
 	) -> Result<usize, TilesetError> {
-		if let Some(texture) = textures.get(handle) {
+		if let Some(texture) = textures.get(handle.clone()) {
 			self.add_texture(handle, texture)
 		} else {
 			Err(TilesetError::ImageNotFound)

--- a/bevy_tileset_core/src/tileset/error.rs
+++ b/bevy_tileset_core/src/tileset/error.rs
@@ -1,6 +1,8 @@
 use crate::prelude::TileGroupId;
-use bevy::asset::AssetIoError;
-use bevy::render::texture::TextureError;
+use bevy::{
+	asset::{AssetLoadError, ReadAssetBytesError},
+	render::texture::TextureError,
+};
 use bevy_tile_atlas::TileAtlasBuilderError;
 use thiserror::Error;
 
@@ -9,7 +11,11 @@ pub enum TilesetError {
 	#[error("image could not be found")]
 	ImageNotFound,
 	#[error("could not load asset: {0:?}")]
-	AssetIoError(AssetIoError),
+	IoError(std::io::Error),
+	#[error("could not load asset: {0:?}")]
+	AssetLoadError(AssetLoadError),
+	#[error("could not load asset: {0:?}")]
+	ReadAssetBytesError(ReadAssetBytesError),
 	#[error("could not read image: {0:?}")]
 	ImageError(TextureError),
 	#[error("could not add tile to atlas: {0:?}")]
@@ -20,4 +26,18 @@ pub enum TilesetError {
 	InvalidDefinition(ron::error::SpannedError),
 	#[error("tile with group ID {0:?} already exists in the tileset")]
 	TileAlreadyExists(TileGroupId),
+	#[error("could not build tile atlas: {0:?}")]
+	TileAtlasBuilderError(TileAtlasBuilderError),
+}
+
+impl From<TileAtlasBuilderError> for TilesetError {
+	fn from(value: TileAtlasBuilderError) -> Self { Self::TileAtlasBuilderError(value) }
+}
+
+impl From<ron::error::SpannedError> for TilesetError {
+	fn from(value: ron::error::SpannedError) -> Self { Self::InvalidDefinition(value) }
+}
+
+impl From<std::io::Error> for TilesetError {
+	fn from(value: std::io::Error) -> Self { Self::IoError(value) }
 }

--- a/bevy_tileset_core/src/tileset/mod.rs
+++ b/bevy_tileset_core/src/tileset/mod.rs
@@ -2,8 +2,11 @@
 
 use std::collections::HashMap;
 
-use bevy::prelude::{Component, Handle, Image, TextureAtlas, Vec2};
-use bevy::reflect::{TypeUuid, TypePath};
+use bevy::{
+	asset::Asset,
+	prelude::{Component, Handle, Image, TextureAtlas, Vec2},
+	reflect::{TypePath, TypeUuid},
+};
 
 pub(crate) use asset::TilesetAssetLoader;
 pub use asset::TilesetDef;
@@ -71,7 +74,7 @@ define_tileset!(
 
 define_tileset!(
 	/// A structure containing the registered tiles as well as a handle to their generated `TextureAtlas`
-	#[derive(Debug, TypeUuid, TypePath)]
+	#[derive(Asset, Debug, TypeUuid, TypePath)]
 	#[uuid = "4a176882-d7b2-429d-af5c-be418ccc3c52"]
 	pub Tileset {
 		/// A handle to the generated texture atlas

--- a/bevy_tileset_tiles/Cargo.toml
+++ b/bevy_tileset_tiles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tileset_tiles"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Gino Valente <gino.valente.code@gmail.com>"]
 description = "Tile definitions used by bevy_tileset"
@@ -12,8 +12,8 @@ readme = "../README.md"
 exclude = ["assets/**/*", ".github/**/*", "screenshots/**/*"]
 
 [dependencies]
-bevy_render = { version = "0.11", default-features = false }
-bevy_asset = { version = "0.11", default-features = false }
+bevy_render = { version = "0.12", default-features = false }
+bevy_asset = { version = "0.12", default-features = false }
 serde = "1.0"
 
 [features]


### PR DESCRIPTION
This is a very, very, very rough transition from bevy 0.11 to 0.12.

As assets v2 dropped with this release a lot of API surface changed.

The biggest problem for me were and are: 

1) LoadContext is now needed to be a mutable reference for quite a few calls and that doesn't play nice with async. 
2) Transitioning between AssetId<Image> and Handle<Image>. One can upgrade an `AssetId` to a strong Handle via `asset_server.get_id_handle(id)` but I don't have a access to an `AssetServer` in the `AssetLoader` load method.